### PR TITLE
Added repository entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "domthing": "^0.3.1",
     "domthingify": "^0.2.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AmpersandJS/ampersand-domthing-mixin"
+  },
   "license": "MIT",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This prevents the `npm WARN` messages from appearing during a `npm install` (as of npm v1.2.20), e.g. `npm WARN package.json ampersand-domthing-mixin@0.1.0 No repository field.`